### PR TITLE
#41287 - Add AND query mode for taxonomy terms

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -318,8 +318,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		wp_die(print_r($query_args['tax_query']));
-
 		$posts_query  = new WP_Query();
 		$query_result = $posts_query->query( $query_args );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -267,13 +267,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 
+		if ( ! empty( $request['relation'] ) ) {
+			$query_args['tax_query'] = array( 'relation' => $request['relation'] );
+		}
+
 		foreach ( $taxonomies as $taxonomy ) {
 			$base        = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 			$tax_exclude = $base . '_exclude';
 
 			if ( ! empty( $request[ $base ] ) ) {
 				if ( is_array( $request[ $base ] ) && 'AND' === $request['relation'] ) {
-					$query_args['tax_query'] = array( 'relation' => 'AND' );
 					foreach ( $request[ $base ] as $term_id ) {
 						$query_args['tax_query'][] = array(
 							'taxonomy'         => $taxonomy->name,
@@ -294,7 +297,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 			if ( ! empty( $request[ $tax_exclude ] ) ) {
 				if ( is_array( $request[ $tax_exclude ] ) && 'AND' === $request['relation'] ) {
-					$query_args['tax_query'] = array( 'relation' => 'AND' );
 					foreach ( $request[ $tax_exclude ] as $term_id ) {
 						$query_args['tax_query'][] = array(
 							'taxonomy'         => $taxonomy->name,
@@ -315,6 +317,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				}
 			}
 		}
+
+		wp_die(print_r($query_args['tax_query']));
 
 		$posts_query  = new WP_Query();
 		$query_result = $posts_query->query( $query_args );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -155,6 +155,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'orderby',
 				'page',
 				'per_page',
+				'relation',
 				'search',
 				'slug',
 				'status',
@@ -863,6 +864,26 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$data     = $response->get_data();
 		$this->assertCount( 1, $data );
 		$this->assertEquals( $id1, $data[0]['id'] );
+	}
+
+	public function test_get_items_tags_relation_query() {
+		$id1 = self::$post_id;
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag1 = wp_insert_term( 'Tag1', 'post_tag' );
+		$tag2 = wp_insert_term( 'Tag2', 'post_tag' );
+
+		wp_set_object_terms( $id1, array( $tag1['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $tag2['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id3, array( $tag1['term_id'], $tag2['term_id'] ), 'post_tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'tags', array( $tag1['term_id'], $tag2['term_id'] ) );
+		$request->set_param( 'relation', 'AND' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id3, $data['0']['id'] );
 	}
 
 	public function test_get_items_tags_exclude_query() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -322,6 +322,15 @@ mockedApiResponse.Schema = {
                                 "type": "string"
                             }
                         },
+                        "relation": {
+                            "required": false,
+                            "enum": [
+                                "AND",
+                                "OR"
+                            ],
+                            "description": "Limit result set based on relationship between multiple taxonomy terms.",
+                            "type": "string"
+                        },
                         "categories": {
                             "required": false,
                             "default": [],


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/41287

If you pass multiple terms in a single taxonomy as parameters to the `/wp-json/wp/v2/posts` endpoint, it does an OR relationship tax query. In this patch, I've added support for a new `relation` parameter which accepts `AND` or `OR` as values and uses that across all terms being queried. 

With the current functionality, if you query multiple terms within a single taxonomy, it uses an OR search inside that taxonomy. If you query multiple taxonomies, it uses an AND search between the different taxonomies. 

So basically this is the current behavior:

URL | Tax Query
-----|-----------
`?tags=1,2` | `tag 1` **OR** `tag 2`
`?tags=1&categories=3` | `tag 1` **AND** `category 3`
`?tags=1,2&categories=3` | (`tag 1` **OR** `tag 2`) **AND** `category 3`
`?tags=1,2&categories=3,4` | (`tag 1` **OR** `tag 2`) **AND** (`category 3` **OR** `category 4`)

With my updated version, it will apply that `relation` parameter to allow you to make AND tax queries within a taxonomy, but it also applies it to ALL terms passed. So the above queries could now be:

URL | Tax Query
-----|-----------
`?tags=1,2&relation=AND` | `tag 1` **AND** `tag 2`
`?tags=1&categories=3&relation=AND` | `tag 1` **AND** `category 3`
`?tags=1,2&categories=3&relation=AND` | `tag 1` **AND** `tag 2` **AND** `category 3`
`?tags=1,2&categories=3,4&relation=AND` | `tag 1` **AND** `tag 2` **AND** `category 3` **AND** `category 4`

But it also supports OR, like this:

URL | Tax Query
-----|-----------
`?tags=1,2&relation=OR` | `tag 1` **OR** `tag 2`
`?tags=1&categories=3&relation=OR` | `tag 1` **OR** `category 3`
`?tags=1,2&categories=3&relation=OR` | `tag 1` **OR** `tag 2` **OR** `category 3`
`?tags=1,2&categories=3,4&relation=OR` | `tag 1` **OR** `tag 2` **OR** `category 3` **OR** `category 4`


## Multiple relation types
Another option I was thinking about would be to allow another optional `{$taxonomy}_relation` parameter, which would allow you to override this global `AND`/`OR` value for a specific taxonomy. It would allow you to do things like this:

URL | Tax Query
-----|-----------
`?tags=1,2&categories=3&relation=OR&tags_relation=AND` | (`tag 1` **AND** `tag 2`) **OR** `category 3`
`?tags=1,2&categories=3,4&relation=OR&tags_relation=AND&categories_relation=AND` | (`tag 1` **AND** `tag 2`) **OR** (`category 3` **AND** `category 4`)