### PR TITLE
#41287 - Add AND query mode for taxonomy terms

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -368,10 +368,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$data = $this->filter_response_by_context( $data, $context );
 
+		$links = $response->get_links();
+
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
-
-		$response->add_links( $this->prepare_links( $post ) );
+		$response->add_links( $links );
 
 		/**
 		 * Filters an attachment returned from the REST API.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1590,7 +1590,18 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $post ) );
+		$links = $this->prepare_links( $post );
+		$response->add_links( $links );
+
+		if ( ! empty( $links['self']['href'] ) ) {
+			$actions = $this->get_available_actions( $post, $request );
+
+			$self = $links['self']['href'];
+
+			foreach ( $actions as $rel ) {
+				$response->add_link( $rel, $self );
+			}
+		}
 
 		/**
 		 * Filters the post data for a response.
@@ -1727,6 +1738,60 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		return $links;
+	}
+
+	/**
+	 * Get the link relations available for the post and current user.
+	 *
+	 * @since 4.9.7
+	 *
+	 * @param WP_Post $post Post object.
+	 * @param WP_REST_Request Request object.
+	 *
+	 * @return array List of link relations.
+	 */
+	protected function get_available_actions( $post, $request ) {
+
+		if ( 'edit' !== $request['context'] ) {
+			return array();
+		}
+
+		$rels = array();
+
+		$post_type = get_post_type_object( $post->post_type );
+
+		if ( 'attachment' !== $this->post_type && current_user_can( $post_type->cap->publish_posts ) ) {
+			$rels[] = 'https://api.w.org/action-publish';
+		}
+
+		if ( 'post' === $post_type->name ) {
+			if ( current_user_can( $post_type->cap->edit_others_posts ) && current_user_can( $post_type->cap->publish_posts ) ) {
+				$rels[] = 'https://api.w.org/action-sticky';
+			}
+		}
+
+		if ( post_type_supports( $post_type->name, 'author' ) ) {
+			if ( current_user_can( $post_type->cap->edit_others_posts ) ) {
+				$rels[] = 'https://api.w.org/action-assign-author';
+			}
+		}
+
+		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+
+		foreach ( $taxonomies as $tax ) {
+			$tax_base   = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;
+			$create_cap = is_taxonomy_hierarchical( $tax->name ) ? $tax->cap->edit_terms : $tax->cap->assign_terms;
+
+			if ( current_user_can( $create_cap ) ) {
+				$rels[] = 'https://api.w.org/action-create-' . $tax_base;
+			}
+
+			if ( current_user_can( $tax->cap->assign_terms ) ) {
+				$rels[] = 'https://api.w.org/action-assign-' . $tax_base;
+			}
+		}
+
+		return $rels;
 	}
 
 	/**
@@ -2069,7 +2134,123 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
+		$schema_links = $this->get_schema_links();
+
+		if ( $schema_links ) {
+			$schema['links'] = $schema_links;
+		}
+
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Retrieve Link Description Objects that should be added to the Schema for the posts collection.
+	 *
+	 * @since 4.9.7
+	 *
+	 * @return array
+	 */
+	protected function get_schema_links() {
+
+		$href = rest_url( "{$this->namespace}/{$this->rest_base}/{id}" );
+
+		$links = array();
+
+		if ( 'attachment' !== $this->post_type ) {
+			$links[] = array(
+				'rel'          => 'https://api.w.org/action-publish',
+				'title'        => __( 'The current user can publish this post.' ),
+				'href'         => $href,
+				'targetSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'status' => array(
+							'type' => 'string',
+							'enum' => array( 'publish', 'future' ),
+						),
+					),
+				),
+			);
+		}
+
+		if ( 'post' === $this->post_type ) {
+			$links[] = array(
+				'rel'          => 'https://api.w.org/action-sticky',
+				'title'        => __( 'The current user can sticky this post.' ),
+				'href'         => $href,
+				'targetSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'sticky' => array(
+							'type' => 'boolean',
+						),
+					),
+				),
+			);
+		}
+
+		if ( post_type_supports( $this->post_type, 'author' ) ) {
+			$links[] = array(
+				'rel'          => 'https://api.w.org/action-assign-author',
+				'title'        => __( 'The current user can change the author on this post.' ),
+				'href'         => $href,
+				'targetSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'author' => array(
+							'type' => 'integer',
+						),
+					),
+				),
+			);
+		}
+
+		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+
+		foreach ( $taxonomies as $tax ) {
+			$tax_base = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;
+
+			/* translators: %s: taxonomy name */
+			$assign_title = sprintf( __( 'The current user can assign terms in the %s taxonomy.' ), $tax->name );
+			/* translators: %s: taxonomy name */
+			$create_title = sprintf( __( 'The current user can create terms in the %s taxonomy.' ), $tax->name );
+
+			$links[] = array(
+				'rel'          => 'https://api.w.org/action-assign-' . $tax_base,
+				'title'        => $assign_title,
+				'href'         => $href,
+				'targetSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						$tax_base => array(
+							'type'  => 'array',
+							'items' => array(
+								'type' => 'integer',
+							),
+						),
+					),
+				),
+			);
+
+			$links[] = array(
+				'rel'          => 'https://api.w.org/action-create-' . $tax_base,
+				'title'        => $create_title,
+				'href'         => $href,
+				'targetSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						$tax_base => array(
+							'type'  => 'array',
+							'items' => array(
+								'type' => 'integer',
+							),
+						),
+					),
+				),
+			);
+		}
+
+		return $links;
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -318,8 +318,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		wp_die(print_r($query_args['tax_query']));
-
 		$posts_query  = new WP_Query();
 		$query_result = $posts_query->query( $query_args );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -267,13 +267,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 
+		if ( ! empty( $request['relation'] ) ) {
+			$query_args['tax_query'] = array( 'relation' => $request['relation'] );
+		}
+
 		foreach ( $taxonomies as $taxonomy ) {
 			$base        = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 			$tax_exclude = $base . '_exclude';
 
 			if ( ! empty( $request[ $base ] ) ) {
 				if ( is_array( $request[ $base ] ) && 'AND' === $request['relation'] ) {
-					$query_args['tax_query'] = array( 'relation' => 'AND' );
 					foreach ( $request[ $base ] as $term_id ) {
 						$query_args['tax_query'][] = array(
 							'taxonomy'         => $taxonomy->name,
@@ -294,7 +297,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 			if ( ! empty( $request[ $tax_exclude ] ) ) {
 				if ( is_array( $request[ $tax_exclude ] ) && 'AND' === $request['relation'] ) {
-					$query_args['tax_query'] = array( 'relation' => 'AND' );
 					foreach ( $request[ $tax_exclude ] as $term_id ) {
 						$query_args['tax_query'][] = array(
 							'taxonomy'         => $taxonomy->name,
@@ -315,6 +317,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				}
 			}
 		}
+
+		wp_die(print_r($query_args['tax_query']));
 
 		$posts_query  = new WP_Query();
 		$query_result = $posts_query->query( $query_args );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -284,6 +284,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'include_children' => false,
 				);
 			}
+
 			if ( ! empty( $request[ $tax_exclude ] ) ) {
 				$query_args['tax_query'][] = array(
 					'taxonomy'         => $taxonomy->name,
@@ -293,6 +294,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'operator'         => 'NOT IN',
 				);
 			}
+
 			if ( ! empty( $request[ $tax_strict ] ) ) {
 				$query_args['tax_query'][] = array(
 					'taxonomy'         => $taxonomy->name,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -272,22 +272,47 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$tax_exclude = $base . '_exclude';
 
 			if ( ! empty( $request[ $base ] ) ) {
-				$query_args['tax_query'][] = array(
-					'taxonomy'         => $taxonomy->name,
-					'field'            => 'term_id',
-					'terms'            => $request[ $base ],
-					'include_children' => false,
-				);
+				if ( is_array( $request[ $base ] ) && 'AND' === $request['relation'] ) {
+					$query_args['tax_query'] = array( 'relation' => 'AND' );
+					foreach ( $request[ $base ] as $term_id ) {
+						$query_args['tax_query'][] = array(
+							'taxonomy'         => $taxonomy->name,
+							'field'            => 'term_id',
+							'terms'            => $term_id,
+							'include_children' => false,
+						);
+					}
+				} else {
+					$query_args['tax_query'][] = array(
+						'taxonomy'         => $taxonomy->name,
+						'field'            => 'term_id',
+						'terms'            => $request[ $base ],
+						'include_children' => false,
+					);
+				}
 			}
 
 			if ( ! empty( $request[ $tax_exclude ] ) ) {
-				$query_args['tax_query'][] = array(
-					'taxonomy'         => $taxonomy->name,
-					'field'            => 'term_id',
-					'terms'            => $request[ $tax_exclude ],
-					'include_children' => false,
-					'operator'         => 'NOT IN',
-				);
+				if ( is_array( $request[ $tax_exclude ] ) && 'AND' === $request['relation'] ) {
+					$query_args['tax_query'] = array( 'relation' => 'AND' );
+					foreach ( $request[ $tax_exclude ] as $term_id ) {
+						$query_args['tax_query'][] = array(
+							'taxonomy'         => $taxonomy->name,
+							'field'            => 'term_id',
+							'terms'            => $term_id,
+							'include_children' => false,
+							'operator'         => 'NOT IN',
+						);
+					}
+				} else {
+					$query_args['tax_query'][] = array(
+						'taxonomy'         => $taxonomy->name,
+						'field'            => 'term_id',
+						'terms'            => $request[ $tax_exclude ],
+						'include_children' => false,
+						'operator'         => 'NOT IN',
+					);
+				}
 			}
 		}
 
@@ -2397,6 +2422,14 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		);
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+
+		if ( ! empty( $taxonomies ) ) {
+			$query_params['relation'] = array(
+				'description' => __( 'Limit result set based on relationship between multiple taxonomy terms.' ),
+				'type'        => 'string',
+				'enum'        => array( 'AND', 'OR' ),
+			);
+		}
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -274,7 +274,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		foreach ( $taxonomies as $taxonomy ) {
 			$base        = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 			$tax_exclude = $base . '_exclude';
-			$tax_strict  = $base . '_strict';
+			$tax_and     = $base . '_and';
 
 			if ( ! empty( $request[ $base ] ) ) {
 				$query_args['tax_query'][] = array(
@@ -295,11 +295,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				);
 			}
 
-			if ( ! empty( $request[ $tax_strict ] ) ) {
+			if ( ! empty( $request[ $tax_and ] ) ) {
 				$query_args['tax_query'][] = array(
 					'taxonomy'         => $taxonomy->name,
 					'field'            => 'term_id',
-					'terms'            => $request[ $tax_strict ],
+					'terms'            => $request[ $tax_and ],
 					'include_children' => false,
 					'operator'         => 'AND',
 				);
@@ -2444,7 +2444,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'default'     => array(),
 			);
 
-			$query_params[ $base . '_strict' ] = array(
+			$query_params[ $base . '_and' ] = array(
 				/* translators: %s: taxonomy name */
 				'description' => sprintf( __( 'Limit result set to all items that have all the specified terms assigned in the %s taxonomy.' ), $base ),
 				'type'        => 'array',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -281,7 +281,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'taxonomy'         => $taxonomy->name,
 					'field'            => 'term_id',
 					'terms'            => $request[ $base ],
-					'include_children' => false
+					'include_children' => false,
 				);
 			}
 			if ( ! empty( $request[ $tax_exclude ] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -267,10 +267,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 
-		if ( ! empty( $request['relation'] ) ) {
-			$query_args['tax_query'] = array( 'relation' => $request['relation'] );
-		}
-
 		foreach ( $taxonomies as $taxonomy ) {
 			$base        = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 			$tax_exclude = $base . '_exclude';
@@ -2412,14 +2408,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		);
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
-
-		if ( ! empty( $taxonomies ) ) {
-			$query_params['relation'] = array(
-				'description' => __( 'Limit result set based on relationship between multiple taxonomies.' ),
-				'type'        => 'string',
-				'enum'        => array( 'AND', 'OR' ),
-			);
-		}
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1350,6 +1350,50 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		}
 	}
 
+	public function test_links_exist() {
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->attachment->create( array( 'post_author' => self::$editor_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/media/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'self', $links );
+	}
+
+	public function test_publish_action_ldo_not_registered() {
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/media' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$publish = wp_list_filter( $schema['links'], array( 'rel' => 'https://api.w.org/action-publish' ) );
+
+		$this->assertCount( 0, $publish, 'LDO not found on schema.' );
+	}
+
+	public function test_publish_action_link_does_not_exists() {
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->attachment->create( array( 'post_author' => self::$editor_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/media/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-publish', $links );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 		if ( file_exists( $this->test_file ) ) {

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -3640,6 +3640,312 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		update_post_meta( $post->ID, 'my_custom_int', $value );
 	}
 
+	public function test_publish_action_ldo_registered() {
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$publish = wp_list_filter( $schema['links'], array( 'rel' => 'https://api.w.org/action-publish' ) );
+
+		$this->assertCount( 1, $publish, 'LDO found on schema.' );
+	}
+
+	public function test_sticky_action_ldo_registered_for_posts() {
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$publish = wp_list_filter( $schema['links'], array( 'rel' => 'https://api.w.org/action-sticky' ) );
+
+		$this->assertCount( 1, $publish, 'LDO found on schema.' );
+	}
+
+	public function test_sticky_action_ldo_not_registered_for_non_posts() {
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/pages' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$publish = wp_list_filter( $schema['links'], array( 'rel' => 'https://api.w.org/action-sticky' ) );
+
+		$this->assertCount( 0, $publish, 'LDO found on schema.' );
+	}
+
+	public function test_author_action_ldo_registered_for_post_types_with_author_support() {
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$publish = wp_list_filter( $schema['links'], array( 'rel' => 'https://api.w.org/action-assign-author' ) );
+
+		$this->assertCount( 1, $publish, 'LDO found on schema.' );
+	}
+
+	public function test_author_action_ldo_not_registered_for_post_types_without_author_support() {
+
+		remove_post_type_support( 'post', 'author' );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$publish = wp_list_filter( $schema['links'], array( 'rel' => 'https://api.w.org/action-assign-author' ) );
+
+		$this->assertCount( 0, $publish, 'LDO found on schema.' );
+	}
+
+	public function test_term_action_ldos_registered() {
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' ) );
+		$data     = $response->get_data();
+		$schema   = $data['schema'];
+
+		$this->assertArrayHasKey( 'links', $schema );
+		$rels = array_flip( wp_list_pluck( $schema['links'], 'rel' ) );
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-assign-categories', $rels );
+		$this->assertArrayHasKey( 'https://api.w.org/action-create-categories', $rels );
+		$this->assertArrayHasKey( 'https://api.w.org/action-assign-tags', $rels );
+		$this->assertArrayHasKey( 'https://api.w.org/action-create-tags', $rels );
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-assign-post_format', $rels );
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-create-post_format', $rels );
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-assign-nav_menu', $rels );
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-create-nav_menu', $rels );
+	}
+
+	public function test_action_links_only_available_in_edit_context() {
+
+		wp_set_current_user( self::$author_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'view' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-publish', $links );
+	}
+
+	public function test_publish_action_link_exists_for_author() {
+
+		wp_set_current_user( self::$author_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-publish', $links );
+	}
+
+	public function test_publish_action_link_does_not_exist_for_contributor() {
+
+		wp_set_current_user( self::$contributor_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$contributor_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-publish', $links );
+	}
+
+	public function test_sticky_action_exists_for_editor() {
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-sticky', $links );
+	}
+
+	public function test_sticky_action_does_not_exist_for_author() {
+
+		wp_set_current_user( self::$author_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-sticky', $links );
+	}
+
+	public function test_sticky_action_does_not_exist_for_non_post_posts() {
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->post->create(
+			array(
+				'post_author' => self::$author_id,
+				'post_type'   => 'page',
+			)
+		);
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-sticky', $links );
+	}
+
+
+	public function test_assign_author_action_exists_for_editor() {
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-assign-author', $links );
+	}
+
+	public function test_assign_author_action_does_not_exist_for_author() {
+
+		wp_set_current_user( self::$author_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-assign-author', $links );
+	}
+
+	public function test_assign_author_action_does_not_exist_for_post_types_without_author_support() {
+
+		remove_post_type_support( 'post', 'author' );
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->post->create();
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-assign-author', $links );
+	}
+
+	public function test_create_term_action_exists_for_editor() {
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-create-categories', $links );
+		$this->assertArrayHasKey( 'https://api.w.org/action-create-tags', $links );
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-create-post_format', $links );
+	}
+
+	public function test_create_term_action_non_hierarchical_exists_for_author() {
+
+		wp_set_current_user( self::$author_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-create-tags', $links );
+	}
+
+	public function test_create_term_action_hierarchical_does_not_exists_for_author() {
+
+		wp_set_current_user( self::$author_id );
+
+		$post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayNotHasKey( 'https://api.w.org/action-create-categories', $links );
+	}
+
+	public function test_assign_term_action_exists_for_contributor() {
+
+		wp_set_current_user( self::$contributor_id );
+
+		$post = self::factory()->post->create(
+			array(
+				'post_author' => self::$contributor_id,
+				'post_status' => 'draft',
+			)
+		);
+		$this->assertGreaterThan( 0, $post );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/posts/{$post}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'https://api.w.org/action-assign-categories', $links );
+		$this->assertArrayHasKey( 'https://api.w.org/action-assign-tags', $links );
+	}
+
 	public function tearDown() {
 		_unregister_post_type( 'youseeeme' );
 		if ( isset( $this->attachment_id ) ) {

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -146,8 +146,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'author_exclude',
 				'before',
 				'categories',
-				'categories_exclude',
 				'categories_and',
+				'categories_exclude',
 				'context',
 				'exclude',
 				'include',
@@ -162,8 +162,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'status',
 				'sticky',
 				'tags',
-				'tags_exclude',
 				'tags_and',
+				'tags_exclude',
 			), $keys
 		);
 	}

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -155,6 +155,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'orderby',
 				'page',
 				'per_page',
+				'relation',
 				'search',
 				'slug',
 				'status',
@@ -863,6 +864,26 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$data     = $response->get_data();
 		$this->assertCount( 1, $data );
 		$this->assertEquals( $id1, $data[0]['id'] );
+	}
+
+	public function test_get_items_tags_relation_query() {
+		$id1 = self::$post_id;
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag1 = wp_insert_term( 'Tag1', 'post_tag' );
+		$tag2 = wp_insert_term( 'Tag2', 'post_tag' );
+
+		wp_set_object_terms( $id1, array( $tag1['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $tag2['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id3, array( $tag1['term_id'], $tag2['term_id'] ), 'post_tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'tags', array( $tag1['term_id'], $tag2['term_id'] ) );
+		$request->set_param( 'relation', 'AND' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id3, $data['0']['id'] );
 	}
 
 	public function test_get_items_tags_exclude_query() {

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -156,7 +156,6 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'orderby',
 				'page',
 				'per_page',
-				'relation',
 				'search',
 				'slug',
 				'status',
@@ -930,29 +929,6 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
-	public function test_get_items_tags_or_categories_query() {
-		$id1      = self::$post_id;
-		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id4      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
-		$category = wp_insert_term( 'My Category', 'category' );
-
-		wp_set_object_terms( $id1, array( $tag['term_id'] ), 'post_tag' );
-		wp_set_object_terms( $id2, array( $category['term_id'] ), 'category' );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'relation', 'OR' );
-		$request->set_param( 'tags', array( $tag['term_id'] ) );
-		$request->set_param( 'categories', array( $category['term_id'] ) );
-
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$this->assertCount( 2, $data );
-		$this->assertEquals( $id2, $data[0]['id'] );
-		$this->assertEquals( $id1, $data[1]['id'] );
-	}
-
 	public function test_get_items_tags_and_categories_exclude_query() {
 		$id1      = self::$post_id;
 		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
@@ -977,32 +953,6 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request->set_param( 'tags_exclude', array( 'my-tag' ) );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
-	}
-
-	public function test_get_items_tags_or_categories_exclude_query() {
-		$id1      = self::$post_id;
-		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id4      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
-		$category = wp_insert_term( 'My Category', 'category' );
-
-		wp_set_object_terms( $id1, array( $tag['term_id'] ), 'post_tag' );
-		wp_set_object_terms( $id2, array( $tag['term_id'] ), 'post_tag' );
-		wp_set_object_terms( $id2, array( $category['term_id'] ), 'category' );
-		wp_set_object_terms( $id3, array( $category['term_id'] ), 'category' );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'tags', array( $tag['term_id'] ) );
-		$request->set_param( 'categories_exclude', array( $category['term_id'] ) );
-		$request->set_param( 'relation', 'OR' );
-
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$this->assertCount( 3, $data );
-		$this->assertEquals( $id2, $data[0]['id'] );
-		$this->assertEquals( $id4, $data[1]['id'] );
-		$this->assertEquals( $id1, $data[2]['id'] );
 	}
 
 	public function test_get_items_tags_and_and_categories_query() {

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -147,6 +147,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'before',
 				'categories',
 				'categories_exclude',
+				'categories_strict',
 				'context',
 				'exclude',
 				'include',
@@ -162,6 +163,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'sticky',
 				'tags',
 				'tags_exclude',
+				'tags_strict',
 			), $keys
 		);
 	}
@@ -866,7 +868,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $id1, $data[0]['id'] );
 	}
 
-	public function test_get_items_tags_relation_query() {
+	public function test_get_items_tags_strict_query() {
 		$id1 = self::$post_id;
 		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
 		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
@@ -877,13 +879,12 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		wp_set_object_terms( $id2, array( $tag2['term_id'] ), 'post_tag' );
 		wp_set_object_terms( $id3, array( $tag1['term_id'], $tag2['term_id'] ), 'post_tag' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'tags', array( $tag1['term_id'], $tag2['term_id'] ) );
-		$request->set_param( 'relation', 'AND' );
+		$request->set_param( 'tags_strict', array( $tag1['term_id'], $tag2['term_id'] ) );
 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertCount( 1, $data );
-		$this->assertEquals( $id3, $data['0']['id'] );
+		$this->assertEquals( $id3, $data[0]['id'] );
 	}
 
 	public function test_get_items_tags_exclude_query() {
@@ -929,6 +930,29 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	public function test_get_items_tags_or_categories_query() {
+		$id1      = self::$post_id;
+		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id4      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
+		$category = wp_insert_term( 'My Category', 'category' );
+
+		wp_set_object_terms( $id1, array( $tag['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $category['term_id'] ), 'category' );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'relation', 'OR' );
+		$request->set_param( 'tags', array( $tag['term_id'] ) );
+		$request->set_param( 'categories', array( $category['term_id'] ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 2, $data );
+		$this->assertEquals( $id2, $data[0]['id'] );
+		$this->assertEquals( $id1, $data[1]['id'] );
+	}
+
 	public function test_get_items_tags_and_categories_exclude_query() {
 		$id1      = self::$post_id;
 		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
@@ -953,6 +977,57 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request->set_param( 'tags_exclude', array( 'my-tag' ) );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	public function test_get_items_tags_or_categories_exclude_query() {
+		$id1      = self::$post_id;
+		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id4      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
+		$category = wp_insert_term( 'My Category', 'category' );
+
+		wp_set_object_terms( $id1, array( $tag['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $tag['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $category['term_id'] ), 'category' );
+		wp_set_object_terms( $id3, array( $category['term_id'] ), 'category' );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'tags', array( $tag['term_id'] ) );
+		$request->set_param( 'categories_exclude', array( $category['term_id'] ) );
+		$request->set_param( 'relation', 'OR' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 3, $data );
+		$this->assertEquals( $id2, $data[0]['id'] );
+		$this->assertEquals( $id4, $data[1]['id'] );
+		$this->assertEquals( $id1, $data[2]['id'] );
+	}
+
+	public function test_get_items_tags_strict_and_categories_query() {
+		$id1      = self::$post_id;
+		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id4      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag1     = wp_insert_term( 'Tag1', 'post_tag' );
+		$tag2     = wp_insert_term( 'Tag2', 'post_tag' );
+		$category = wp_insert_term( 'My Category', 'category' );
+
+		wp_set_object_terms( $id1, array( $tag1['term_id'], $tag2['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id1, array( $category['term_id'] ), 'category' );
+		wp_set_object_terms( $id2, array( $tag1['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $category['term_id'] ), 'category' );
+		wp_set_object_terms( $id3, array( $category['term_id'] ), 'category' );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'tags_strict', array( $tag1['term_id'], $tag2['term_id'] ) );
+		$request->set_param( 'categories', array( $category['term_id'] ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id1, $data[0]['id'] );
 	}
 
 	public function test_get_items_sticky() {

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -147,7 +147,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'before',
 				'categories',
 				'categories_exclude',
-				'categories_strict',
+				'categories_and',
 				'context',
 				'exclude',
 				'include',
@@ -163,7 +163,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'sticky',
 				'tags',
 				'tags_exclude',
-				'tags_strict',
+				'tags_and',
 			), $keys
 		);
 	}
@@ -868,7 +868,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $id1, $data[0]['id'] );
 	}
 
-	public function test_get_items_tags_strict_query() {
+	public function test_get_items_tags_and_query() {
 		$id1 = self::$post_id;
 		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
 		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
@@ -879,7 +879,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		wp_set_object_terms( $id2, array( $tag2['term_id'] ), 'post_tag' );
 		wp_set_object_terms( $id3, array( $tag1['term_id'], $tag2['term_id'] ), 'post_tag' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'tags_strict', array( $tag1['term_id'], $tag2['term_id'] ) );
+		$request->set_param( 'tags_and', array( $tag1['term_id'], $tag2['term_id'] ) );
 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -1005,7 +1005,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $id1, $data[2]['id'] );
 	}
 
-	public function test_get_items_tags_strict_and_categories_query() {
+	public function test_get_items_tags_and_and_categories_query() {
 		$id1      = self::$post_id;
 		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
 		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
@@ -1021,7 +1021,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		wp_set_object_terms( $id3, array( $category['term_id'] ), 'category' );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'tags_strict', array( $tag1['term_id'], $tag2['term_id'] ) );
+		$request->set_param( 'tags_and', array( $tag1['term_id'], $tag2['term_id'] ) );
 		$request->set_param( 'categories', array( $category['term_id'] ) );
 
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -322,6 +322,15 @@ mockedApiResponse.Schema = {
                                 "type": "string"
                             }
                         },
+                        "relation": {
+                            "required": false,
+                            "enum": [
+                                "AND",
+                                "OR"
+                            ],
+                            "description": "Limit result set based on relationship between multiple taxonomy terms.",
+                            "type": "string"
+                        },
                         "categories": {
                             "required": false,
                             "default": [],

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -349,7 +349,7 @@ mockedApiResponse.Schema = {
                                 "type": "integer"
                             }
                         },
-                        "categories_strict": {
+                        "categories_and": {
                             "required": false,
                             "default": [],
                             "description": "Limit result set to all items that have all the specified terms assigned in the categories taxonomy.",
@@ -376,7 +376,7 @@ mockedApiResponse.Schema = {
                                 "type": "integer"
                             }
                         },
-                        "tags_strict": {
+                        "tags_and": {
                             "required": false,
                             "default": [],
                             "description": "Limit result set to all items that have all the specified terms assigned in the tags taxonomy.",

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -328,7 +328,7 @@ mockedApiResponse.Schema = {
                                 "AND",
                                 "OR"
                             ],
-                            "description": "Limit result set based on relationship between multiple taxonomy terms.",
+                            "description": "Limit result set based on relationship between multiple taxonomies.",
                             "type": "string"
                         },
                         "categories": {
@@ -349,6 +349,15 @@ mockedApiResponse.Schema = {
                                 "type": "integer"
                             }
                         },
+                        "categories_strict": {
+                            "required": false,
+                            "default": [],
+                            "description": "Limit result set to all items that have all the specified terms assigned in the categories taxonomy.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
                         "tags": {
                             "required": false,
                             "default": [],
@@ -362,6 +371,15 @@ mockedApiResponse.Schema = {
                             "required": false,
                             "default": [],
                             "description": "Limit result set to all items except those that have the specified term assigned in the tags taxonomy.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "tags_strict": {
+                            "required": false,
+                            "default": [],
+                            "description": "Limit result set to all items that have all the specified terms assigned in the tags taxonomy.",
                             "type": "array",
                             "items": {
                                 "type": "integer"

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -322,15 +322,6 @@ mockedApiResponse.Schema = {
                                 "type": "string"
                             }
                         },
-                        "relation": {
-                            "required": false,
-                            "enum": [
-                                "AND",
-                                "OR"
-                            ],
-                            "description": "Limit result set based on relationship between multiple taxonomies.",
-                            "type": "string"
-                        },
                         "categories": {
                             "required": false,
                             "default": [],


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/41287

If you pass multiple terms in a single taxonomy as parameters to the `/wp-json/wp/v2/posts` endpoint, it uses an OR relationship between the terms within that taxonomy. If you query multiple taxonomies, it uses an AND search between the different taxonomies. 

In this patch, I've added support for a new `{$tax}_and` parameter which queries using an AND relationship between terms. This is consistent with the existing parameter of `{$tax}_exclude` for a NOT IN type query. 

I've also added a new parameter, `relation`, which allows you to specific an OR relationship between taxonomies being queried. 

So basically this is the current behavior:

URL | Tax Query Matches
-----|-----------
`?tags=1,2` | `tag 1` **OR** `tag 2`
`?tags=1&categories=3` | `tag 1` **AND** `category 3`
`?tags=1,2&categories=3` | (`tag 1` **OR** `tag 2`) **AND** `category 3`
`?tags=1,2&categories=3,4` | (`tag 1` **OR** `tag 2`) **AND** (`category 3` **OR** `category 4`)

With my updated version, you can use a `{$tax}_and` type parameter to force AND matching on the terms within a specific taxonomy. 

URL | Tax Query Matches
-----|-----------
`?tags_and=1,2` | `tag 1` **AND** `tag 2`
`?tags_and=1,2&categories=3` | `tag 1` **AND** `tag 2` **AND** `category 3`
`?tags_and=1,2&categories_and=3,4` | `tag 1` **AND** `tag 2` **AND** `category 3` **AND** `category 4`

You can also use the `relation` parameter to allow you to make OR queries across multiple taxonomies. 

URL | Tax Query Matches
-----|-----------
`?tags=1&categories=3&relation=OR` | `tag 1` **OR** `category 3`
`?tags=1,2&categories=3&relation=OR` | `tag 1` **OR** `tag 2` **OR** `category 3`
`?tags=1,2&categories=3,4&relation=OR` | `tag 1` **OR** `tag 2` **OR** `category 3` **OR** `category 4`

Or you can combine the two together to make very complex tax queries.

URL | Tax Query Matches
-----|-----------
`?tags_and=1,2&tags=3&relation=OR` | (`tag 1` **AND** `tag 2`) **OR** `tag 3`
`?tags_and=1,2&categories=3&relation=OR` | (`tag 1` **AND** `tag 2`) **OR** `category 3`
`?tags_and=1,2&categories_and=3,4&relation=OR` | (`tag 1` **AND** `tag 2`) **OR** (`category 3` **AND** `category 4`)
`?tags_and=1,2&categories_exclude=3,4&relation=OR` | (`tag 1` **AND** `tag 2`) **OR** ( **NOT** `category 3` **OR** `category4` )

You can even use the `relation` parameter for queries within a single taxonomy that use multiple types of operators:

URL | Tax Query Matches
-----|-----------
`?tags_and=1,2&tags=3,4&relation=OR` | (`tag 1` **AND** `tag 2`) **OR** `tag 3` **OR** `tag 4`
`?tags_and=1,2&tags_exclude=3,4&relation=OR` | (`tag 1` **AND** `tag 2`) **OR** ( **NOT** `tag 3` **OR** `tag 4` )
